### PR TITLE
Fatal error on refunds if product is not in database anymore

### DIFF
--- a/includes/class-wc-klarna-order-management-request.php
+++ b/includes/class-wc-klarna-order-management-request.php
@@ -316,7 +316,24 @@ class WC_Klarna_Order_Management_Request {
 						}
 					}
 
-					$type                = $product->is_downloadable() || $product->is_virtual() ? 'digital' : 'physical';
+					 /**
+                     *
+                     *  If a product is not available inside of WC anymore wc_get_product() will return false
+                     *  and the default check will fail resulting in an fatal error, creating the Refund with WC but not sending it to Klarna
+                     *  This fallback allows DEVs to provide the product type which they saved before.
+                     *
+                     *  Alternatively KOM or KCO could save this onformation on order creation.
+                     *
+                     **/
+
+
+                     if(is_object($product) && method_exists($product, 'is_downloadable')){
+                           $type = $product->is_downloadable() || $product->is_virtual() ? 'digital' : 'physical';
+                     } else {
+                           $type = apply_filters('kom_line_item_product_type','physical',$item);
+                     }
+					
+					
 					$reference           = $order_lines_processor->get_item_reference( $item );
 					$name                = $order_lines_processor->get_item_name( $item );
 					$quantity            = abs( $order_lines_processor->get_item_quantity( $item ) );


### PR DESCRIPTION
We recently discovered a problem with creating refunds with KOM when refunded products are not inside of the shop anymore.
WooCommerce would then still create a refund but not be able to send it to Klarna creating issues in order management - especially when used together with some ERP solutions.

In our case the system considered the error 500 as failure in transmitting the refund and retried sending it indefinitely.
Unfortunately this was discovered after a big sale with 1000+ orders of products which afterwards were removed from the shop but still have
a quite high probability of getting returned (but are not planned to be sold in the near future again).

We helped ourself with a fork of the plugin but would really appreciate if this but would really appreciate a permanent fix for this situation.

Our suggestion is to add an additional check for $product and using a filter to provide the product type which could be used by developers to circumvent the rror.
Additionally Klarna could save the product type at the time of purchase.


add_action('woocommerce_new_order_item', [$this,'addOrderItemMeta'], 10, 3);
public function addOrderItemMeta($item_id, $item, $order_id){

    if(method_exists($item,'get_product')){

        $product = $item -> get_product();

        if($product !== false && $product !== null){

            $item -> add_meta_data('_is_virtual',($product -> is_downloadable() || $product -> is_virtual()),true);
            $item -> save();

        }

    }

}