### PR TITLE
Check the coupon type before adding to order line

### DIFF
--- a/includes/class-wc-klarna-order-management-order-lines.php
+++ b/includes/class-wc-klarna-order-management-order-lines.php
@@ -159,7 +159,12 @@ class WC_Klarna_Order_Management_Order_Lines {
 		 * @var WC_Order_Item_Coupon $order_item WooCommerce order item coupon.
 		 */
 		foreach ( $order->get_items( 'coupon' ) as $order_item ) {
-			$this->order_lines[] = $this->process_order_item_coupon( $order_item, $order );
+
+			/* Only smart coupons are added to the capture order lines, or if the merchant is a Klarna US merchant. */
+			$coupon = new WC_Coupon( $order_item->get_name() );
+			if ( 'smart_coupon' === $coupon->get_discount_type() || 'US' === $this->klarna_country ) {
+				$this->order_lines[] = $this->process_order_item_coupon( $order_item, $order );
+			}
 		}
 
 		$added_surcharge = json_decode( get_post_meta( $this->order_id, '_kco_added_surcharge', true ), true );


### PR DESCRIPTION
Fixes #64 

This has been tested with WC standard coupons, smart coupons, and with US MID.