### PR TITLE
Fix tax rate is null

### DIFF
--- a/includes/class-wc-klarna-order-management-order-lines.php
+++ b/includes/class-wc-klarna-order-management-order-lines.php
@@ -456,7 +456,8 @@ class WC_Klarna_Order_Management_Order_Lines {
 			}
 		}
 
-		return ! empty( floatval( $order_item->get_total() ) ) ? intval( number_format( 100 * $order_item->get_total_tax() / $order_item->get_total(), 0, '', '' ) ) : 0;
+		// If we get here, there is no tax set for the order item.
+		return 0;
 	}
 
 

--- a/includes/class-wc-klarna-order-management-order-lines.php
+++ b/includes/class-wc-klarna-order-management-order-lines.php
@@ -455,6 +455,8 @@ class WC_Klarna_Order_Management_Order_Lines {
 				}
 			}
 		}
+
+		return ! empty( floatval( $order_item->get_total() ) ) ? intval( number_format( 100 * $order_item->get_total_tax() / $order_item->get_total(), 0, '', '' ) ) : 0;
 	}
 
 


### PR DESCRIPTION
We need a third case where the item is not a coupon, and when we cannot find a tax rate in the tax items.

In the third case, most likely, the tax is supposed to be zero, but we still try to calculate the tax.