### PR TITLE
Print the remaining authorized amount

### DIFF
--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -413,8 +413,15 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 							$order = wc_get_order( $order_id );
 							$order->add_order_note( __( 'Klarna could not charge the customer. Please try again later. If that still fails, the customer may have to create a new subscription or add funds to their payment method if they wish to continue.', 'klarna-order-management-for-woocommerce' ) );
 						} else {
+							$error_message = $response->get_error_message();
+
+							if ( ! is_array( $error_message ) && false !== strpos( $error_message, 'Captured amount is higher than the remaining authorized amount.' ) ) {
+								$error_message = str_replace( '. Capture not possible.', sprintf( ': %s %s.', $klarna_order->remaining_authorized_amount / 100, $klarna_order->purchase_currency ), $error_message );
+							}
+
 							// translators: %s: Error message from Klarna.
-							$order->add_order_note( __( sprintf( 'Could not capture Klarna order. %s', $response->get_error_message() ), 'klarna-order-management-for-woocommerce' ) );
+							$order->add_order_note( __( sprintf( 'Could not capture Klarna order. %s', $error_message ), 'klarna-order-management-for-woocommerce' ) );
+
 						}
 
 						$order->set_status( 'on-hold' );

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -420,7 +420,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 							}
 
 							// translators: %s: Error message from Klarna.
-							$order->add_order_note( __( sprintf( 'Could not capture Klarna order. %s', $error_message ), 'klarna-order-management-for-woocommerce' ) );
+							$order->add_order_note( sprintf( __( 'Could not capture Klarna order. %s', 'klarna-order-management-for-woocommerce' ), $error_message ) );
 
 						}
 


### PR DESCRIPTION
Currently, the most common reason for seeing this error message is rounding errors, and since the merchant does not know how much the remaining authorized amount is, they have to verify with the merchant portal (or contact our support team for further help).