### PR TITLE
Do not send request if body is not JSON

### DIFF
--- a/classes/request/class-kom-request.php
+++ b/classes/request/class-kom-request.php
@@ -160,7 +160,7 @@ abstract class KOM_Request {
 	public function request() {
 		$url  = $this->get_request_url();
 		$args = $this->get_request_args();
-		if ( is_wp_error( $args ) ) {
+		if ( is_wp_error( $args ) || ( isset( $args['body'] ) && is_null( json_decode( $args['body'] ) ) ) ) {
 			return $args;
 		}
 		$response = wp_remote_request( $url, $args );


### PR DESCRIPTION
The `is_null` check is necessary as `json_decode` only return `null` if decoding fails  (which is what we're interested in) or if the JSON object actually contains `null` which is useless for our purpose.