### PR TITLE
Use the product's tax rate if available

### DIFF
--- a/classes/request/post/class-kom-request-post-refund.php
+++ b/classes/request/post/class-kom-request-post-refund.php
@@ -106,7 +106,7 @@ class KOM_Request_Post_Refund extends KOM_Request_Post {
 						if ( $item->get_product_id() === $order_item->get_product_id() ) {
 							$order_line_total    = round( ( $order->get_line_subtotal( $order_item, false ) * 100 ) );
 							$order_line_tax      = round( ( $order->get_line_tax( $order_item ) * 100 ) );
-							$order_line_tax_rate = ( 0 != $order_line_tax && 0 != $order_line_total ) ? round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) : 0; // phpcs:ignore WordPress.PHP.StrictComparisons -- Non strict is ok here.
+							$order_line_tax_rate = empty( $order_line_tax + $order_line_total ) ? 0 : reset( WC_Tax::get_base_tax_rates( $product->get_tax_class() ) )['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 );
 						}
 					}
 

--- a/classes/request/post/class-kom-request-post-refund.php
+++ b/classes/request/post/class-kom-request-post-refund.php
@@ -106,7 +106,7 @@ class KOM_Request_Post_Refund extends KOM_Request_Post {
 						if ( $item->get_product_id() === $order_item->get_product_id() ) {
 							$order_line_total    = round( ( $order->get_line_subtotal( $order_item, false ) * 100 ) );
 							$order_line_tax      = round( ( $order->get_line_tax( $order_item ) * 100 ) );
-							$order_line_tax_rate = empty( $order_line_tax + $order_line_total ) ? 0 : reset( WC_Tax::get_base_tax_rates( $product->get_tax_class() ) )['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 );
+							$order_line_tax_rate = ( 0 !== $order_line_tax && 0 !== $order_line_total ) ? reset( WC_Tax::get_base_tax_rates( $product->get_tax_class() ) )['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) : 0;
 						}
 					}
 


### PR DESCRIPTION
Currently, we calculate the tax rate by using total amounts. While this is correct in terms of what the amount we refund is, still it is usually different from the product's tax rate.

With these changes, we'll use the individual product's tax rate (similar to how we do in Klarna Checkout), and default to calculate tax rate based on total amounts (current behavior).