### PR TITLE
Add compatibility with WooCommerce's HPOS

### DIFF
--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -66,7 +66,7 @@ class WC_Klarna_Meta_Box {
 			return;
 		}
 		// False if automatic settings are enabled, true if not. If true then show the option.
-		if ( ! empty( get_post_meta( $order_id, '_transaction_id', true ) ) || ! empty( get_post_meta( $order_id, '_wc_klarna_order_id', true ) ) ) {
+		if ( ! empty( $order->get_transaction_id() ) || ! empty( $order->get_meta( '_wc_klarna_order_id', true ) ) ) {
 
 			$klarna_order = WC_Klarna_Order_Management::get_instance()->retrieve_klarna_order( $order_id );
 
@@ -86,13 +86,14 @@ class WC_Klarna_Meta_Box {
 	 */
 	public function print_standard_content( $klarna_order ) {
 		$order_id           = get_the_ID();
+		$order              = wc_get_order( $order_id );
 		$settings           = get_option( 'kom_settings' );
 		$actions            = array();
 		$actions['capture'] = ( ! isset( $settings['kom_auto_capture'] ) || 'yes' === $settings['kom_auto_capture'] ) ? false : true;
 		$actions['cancel']  = ( ! isset( $settings['kom_auto_cancel'] ) || 'yes' === $settings['kom_auto_cancel'] ) ? false : true;
 		$actions['sync']    = ( ! isset( $settings['kom_auto_order_sync'] ) || 'yes' === $settings['kom_auto_order_sync'] ) ? false : true;
 		$actions['any']     = ( $actions['capture'] || $actions['cancel'] || $actions['sync'] );
-		$environment        = ! empty( get_post_meta( $order_id, '_wc_klarna_environment', true ) ) ? get_post_meta( $order_id, '_wc_klarna_environment', true ) : '';
+		$environment        = ! empty( $order->get_meta( '_wc_klarna_environment', true ) ) ? $order->get_meta( '_wc_klarna_environment', true ) : '';
 
 		?>
 		<div class="kom-meta-box-content">
@@ -192,10 +193,11 @@ class WC_Klarna_Meta_Box {
 	 * @return bool Should Capture-related stuff be in the output?
 	 */
 	public function want_output_capture( $order_id, $klarna_order, $actions ) {
+		$order = wc_get_order( $order_id );
 		if ( ! $actions['capture'] ) {
 			return false; // Capture is on auto, don't present action.
 		}
-		if ( ! empty( get_post_meta( $order_id, '_wc_klarna_capture_id' ) ) ) {
+		if ( ! empty( $order->get_meta( '_wc_klarna_capture_id' ) ) ) {
 			return false; // Already captured, can't capture again.
 		}
 		if ( in_array( $klarna_order->status, array( 'CAPTURED', 'PART_CAPTURED', 'CANCELLED' ), true ) ) {
@@ -218,10 +220,11 @@ class WC_Klarna_Meta_Box {
 	 * @return bool Should Capture-related stuff be in the output?
 	 */
 	public function want_output_cancel( $order_id, $klarna_order, $actions ) {
+		$order = wc_get_order( $order_id );
 		if ( ! $actions['cancel'] ) {
 			return false; // Cancel is on auto, don't present action.
 		}
-		if ( ! empty( get_post_meta( $order_id, '_wc_klarna_pending_to_cancelled' ) ) ) {
+		if ( ! empty( $order->get_meta( '_wc_klarna_pending_to_cancelled', true ) ) ) {
 			return false; // A cancellation is already pending, can't cancel again.
 		}
 		if ( ! in_array( $klarna_order->status, array( 'CAPTURED', 'PART_CAPTURED' ), true ) ) {
@@ -344,7 +347,7 @@ class WC_Klarna_Meta_Box {
 			return;
 		}
 		if ( ! empty( $klarna_order_id ) ) {
-			update_post_meta( $post_id, '_wc_klarna_order_id', $klarna_order_id );
+			$order->update_meta_data( '_wc_klarna_order_id', $klarna_order_id );
 			$order->set_transaction_id( $klarna_order_id );
 			$order->save();
 		}

--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
 /**
  * WC_Klarna_Pending_Orders class.
  *
@@ -43,11 +46,14 @@ class WC_Klarna_Meta_Box {
 	 * @return void
 	 */
 	public function kom_meta_box( $post_type ) {
-		if ( 'shop_order' === $post_type ) {
-			$order_id = get_the_ID();
-			$order    = wc_get_order( $order_id );
+		$hpos_enabled = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+		$screen       = $hpos_enabled ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		$order_id     = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+
+		if ( 'shop_order' === OrderUtil::get_order_type( $order_id ) ) {
+			$order = wc_get_order( $order_id );
 			if ( in_array( $order->get_payment_method(), array( 'kco', 'klarna_payments' ), true ) ) {
-				add_meta_box( 'kom_meta_box', __( 'Klarna Order Management', 'klarna-order-management-for-woocommerce' ), array( $this, 'kom_meta_box_content' ), 'shop_order', 'side', 'core' );
+				add_meta_box( 'kom_meta_box', __( 'Klarna Order Management', 'klarna-order-management-for-woocommerce' ), array( $this, 'kom_meta_box_content' ), $screen, 'side', 'core' );
 			}
 		}
 	}

--- a/classes/class-wc-klarna-order-management-order-lines.php
+++ b/classes/class-wc-klarna-order-management-order-lines.php
@@ -93,7 +93,7 @@ class WC_Klarna_Order_Management_Order_Lines {
 			$this->separate_sales_tax = true;
 		}
 
-		$this->klarna_country = strtoupper( get_post_meta( $order_id, '_wc_klarna_country', true ) );
+		$this->klarna_country = strtoupper( $this->order->get_meta( '_wc_klarna_country', true ) );
 	}
 
 	/**
@@ -194,7 +194,7 @@ class WC_Klarna_Order_Management_Order_Lines {
 			$this->order_lines[] = $order_item;
 		}
 
-		$added_surcharge = json_decode( get_post_meta( $this->order_id, '_kco_added_surcharge', true ), true );
+		$added_surcharge = json_decode( $this->order->get_meta( '_kco_added_surcharge', true ), true );
 
 		if ( ! empty( $added_surcharge ) ) {
 			$this->order_lines[] = $added_surcharge;
@@ -237,7 +237,7 @@ class WC_Klarna_Order_Management_Order_Lines {
 	 * @return array
 	 */
 	public function process_order_item_shipping( $order_item, $order ) {
-		$reference = json_decode( get_post_meta( $order->get_id(), '_kco_kss_data', true ), true );
+		$reference = json_decode( $this->order->get_meta( '_kco_kss_data', true ), true );
 
 		return array(
 			'reference'             => ( isset( $reference['id'] ) ) ? $reference['id'] : $this->get_item_reference( $order_item ),

--- a/classes/class-wc-klarna-pending-orders.php
+++ b/classes/class-wc-klarna-pending-orders.php
@@ -86,15 +86,17 @@ class WC_Klarna_Pending_Orders {
 	private static function get_order_id_from_klarna_order_id( $klarna_order_id ) {
 		$orders = wc_get_orders(
 			array(
-				'status'     => array_keys( wc_get_order_statuses() ),
-				'meta_key'   => '_wc_klarna_order_id',
-				'meta_value' => $klarna_order_id,
+				'meta_query' => array(
+					'meta_key'   => '_wc_klarna_order_id',
+					'meta_value' => $klarna_order_id,
+					'compare'    => '=',
+				),
 			)
 		);
-		$order  = reset( $orders );
 
-		// If zero matching orders were found, return.
-		if ( ! $orders ) {
+		$order = reset( $orders );
+
+		if ( empty( $orders ) ) {
 			return;
 		}
 

--- a/classes/class-wc-klarna-pending-orders.php
+++ b/classes/class-wc-klarna-pending-orders.php
@@ -62,8 +62,9 @@ class WC_Klarna_Pending_Orders {
 			$order->add_order_note( 'Payment with Klarna is accepted.' );
 		} elseif ( 'REJECTED' === $klarna_order->fraud_status || 'STOPPED' === $klarna_order->fraud_status ) {
 			// Set meta field so order cancellation doesn't trigger Klarna API requests.
-			update_post_meta( $order_id, '_wc_klarna_pending_to_cancelled', true, true );
+			$order->update_meta_data( '_wc_klarna_pending_to_cancelled', true );
 			$order->update_status( 'cancelled', 'Klarna order rejected.' );
+			$order->save();
 			wc_mail(
 				get_option( 'admin_email' ),
 				'Klarna order rejected',
@@ -83,23 +84,21 @@ class WC_Klarna_Pending_Orders {
 	 * @return $order_id
 	 */
 	private static function get_order_id_from_klarna_order_id( $klarna_order_id ) {
-		$query_args = array(
-			'post_type'   => wc_get_order_types(),
-			'post_status' => array_keys( wc_get_order_statuses() ),
-			'meta_key'    => '_wc_klarna_order_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-			'meta_value'  => $klarna_order_id, // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		$orders = wc_get_orders(
+			array(
+				'status'     => array_keys( wc_get_order_statuses() ),
+				'meta_key'   => '_wc_klarna_order_id',
+				'meta_value' => $klarna_order_id,
+			)
 		);
-
-		$orders = get_posts( $query_args );
+		$order  = reset( $orders );
 
 		// If zero matching orders were found, return.
-		if ( empty( $orders ) ) {
+		if ( ! $orders ) {
 			return;
 		}
 
-		$order_id = $orders[0]->ID;
-
-		return $order_id;
+		return $order->get_id();
 	}
 
 	/**
@@ -109,6 +108,6 @@ class WC_Klarna_Pending_Orders {
 	 * @return string|bool
 	 */
 	private static function get_klarna_order_id_from_order_id( $order_id ) {
-		return get_post_meta( $order_id, '_wc_klarna_order_id', true );
+		return wc_get_order( $order_id )->get_meta( '_wc_klarna_order_id', true );
 	}
 }

--- a/classes/class-wc-klarna-sellers-app.php
+++ b/classes/class-wc-klarna-sellers-app.php
@@ -59,7 +59,7 @@ class WC_Klarna_Sellers_App {
 			// Set post metas.
 			$order->update_meta_data( '_wc_klarna_order_id', $order->get_transaction_id() );
 			$order->update_meta_data( '_wc_klarna_country', wc_get_base_location()['country'] );
-			$order->update_meta_data( '_wc_klarna_enviroment', self::get_klarna_environment( $order->get_payment_method() ) );
+			$order->update_meta_data( '_wc_klarna_environment', self::get_klarna_environment( $order->get_payment_method() ) );
 			$order->save();
 
 			$klarna_order = WC_Klarna_Order_Management::get_instance()->retrieve_klarna_order( $post_id );

--- a/classes/class-wc-klarna-sellers-app.php
+++ b/classes/class-wc-klarna-sellers-app.php
@@ -50,12 +50,17 @@ class WC_Klarna_Sellers_App {
 		}
 
 		// Check that this is an update, and that we have a transaction number, and that the payment method is set to KCO or KP.
-		if ( $update && ! empty( get_post_meta( $post_id, '_transaction_id', true ) ) && in_array( get_post_meta( $post_id, '_payment_method', true ), array( 'kco', 'klarna_payments' ), true ) ) {
-			$order = wc_get_order( $post_id );
+		$order = wc_get_order( $post_id );
+		if ( empty( $order ) ) {
+			return;
+		}
+
+		if ( $update && ! empty( $order->get_transaction_id() ) && in_array( $order->get_payment_method(), array( 'kco', 'klarna_payments' ), true ) ) {
 			// Set post metas.
-			update_post_meta( $post_id, '_wc_klarna_order_id', $order->get_transaction_id() );
-			update_post_meta( $post_id, '_wc_klarna_country', wc_get_base_location()['country'] );
-			update_post_meta( $post_id, '_wc_klarna_enviroment', self::get_klarna_environment( get_post_meta( $post_id, '_payment_method', true ) ) );
+			$order->update_meta_data( '_wc_klarna_order_id', $order->get_transaction_id() );
+			$order->update_meta_data( '_wc_klarna_country', wc_get_base_location()['country'] );
+			$order->update_meta_data( '_wc_klarna_enviroment', self::get_klarna_environment( $order->get_payment_method() ) );
+			$order->save();
 
 			$klarna_order = WC_Klarna_Order_Management::get_instance()->retrieve_klarna_order( $post_id );
 

--- a/classes/request/class-kom-request.php
+++ b/classes/request/class-kom-request.php
@@ -94,12 +94,8 @@ abstract class KOM_Request {
 	 * @return mixed
 	 */
 	public function get_klarna_order_id() {
-		$transaction_id = get_post_meta( $this->order_id, '_transaction_id', true );
-		if ( $transaction_id ) {
-			return $transaction_id;
-		}
-
-		return get_post_meta( $this->order_id, '_wc_klarna_order_id', true );
+		$order = wc_get_order( $this->order_id );
+		return ! empty( $order->get_transaction_id() ) ? $order->get_transaction_id() : $order->get_meta( '_wc_klarna_order_id', true );
 	}
 
 	/**
@@ -124,14 +120,12 @@ abstract class KOM_Request {
 	/**
 	 * Get the country code for the underlaying order.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	protected function get_klarna_country() {
-		$country = '';
-		if ( get_post_meta( $this->order_id, '_wc_klarna_country', true ) ) {
-			$country = get_post_meta( $this->order_id, '_wc_klarna_country', true );
-		}
-		return $country;
+		$order   = wc_get_order( $this->order_id );
+		$country = $order->get_meta( '_wc_klarna_country', true );
+		return $country ? $country : '';
 	}
 
 	/**
@@ -243,7 +237,8 @@ abstract class KOM_Request {
 	 * @return string
 	 */
 	protected function get_auth_component( $component_name ) {
-		$component = get_post_meta( $this->order_id, "_wc_klarna_{$component_name}", true );
+		$order     = wc_get_order( $this->order_id );
+		$component = $order->get_meta( "_wc_klarna_{$component_name}", true );
 		if ( ! empty( $component ) ) {
 			return iconv( mb_detect_encoding( $component, mb_detect_order(), true ), 'UTF-8', $component );
 		}

--- a/classes/request/post/class-kom-request-post-capture.php
+++ b/classes/request/post/class-kom-request-post-capture.php
@@ -74,10 +74,11 @@ class KOM_Request_Post_Capture extends KOM_Request_Post {
 	 */
 	protected function get_kss_shipment_data() {
 		$kss_shipment_data = array();
+		$order             = wc_get_order( $this->order_id );
 
-		$kco_kss_data     = json_decode( get_post_meta( $this->order_id, '_kco_kss_data', true ), true );
-		$kss_tracking_id  = get_post_meta( $this->order_id, '_kss_tracking_id', true );
-		$kss_tracking_url = get_post_meta( $this->order_id, '_kss_tracking_url', true );
+		$kco_kss_data     = json_decode( $order->get_meta( '_kco_kss_data', true ), true );
+		$kss_tracking_id  = $order->get_meta( '_kss_tracking_id', true );
+		$kss_tracking_url = $order->get_meta( '_kss_tracking_url', true );
 		isset( $kco_kss_data['delivery_details']['carrier'] ) ? $kss_shipment_data['shipping_company'] = $kco_kss_data['delivery_details']['carrier'] : '';
 		isset( $kco_kss_data['shipping_method'] ) ? $kss_shipment_data['shipping_method']              = $kco_kss_data['shipping_method'] : '';
 		isset( $kss_tracking_id ) ? $kss_shipment_data['tracking_number']                              = $kss_tracking_id : '';

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -147,16 +147,20 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 				2
 			);
 
-			// Declare HPOS compatibility
-			add_action(
-				'before_woocommerce_init',
-				function() {
-					if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-						\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
-					}
-				}
-			);
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatability' ) );
+		}
 
+		/**
+		 * Declare compatibility with WooCommerce features.
+		 *
+		 * @return void
+		 */
+		public function declare_wc_compatability() {
+
+			// Declare HPOS compatibility.
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
 		}
 
 		/**

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -494,7 +494,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 				$response = $request->request();
 
 				if ( ! is_wp_error( $response ) ) {
-					$order->add_order_note( wc_price( $amount, array( 'currency' => $order->get_meta( '_order_currency', true ) ) ) . ' refunded via Klarna.' );
+					$order->add_order_note( wc_price( $amount, array( 'currency' => $order->get_currency() ) ) . ' refunded via Klarna.' );
 					$order->update_meta_data( '_wc_klarna_capture_id', $response );
 					$order->save();
 

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -495,9 +495,6 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 
 				if ( ! is_wp_error( $response ) ) {
 					$order->add_order_note( wc_price( $amount, array( 'currency' => $order->get_currency() ) ) . ' refunded via Klarna.' );
-					$order->update_meta_data( '_wc_klarna_capture_id', $response );
-					$order->save();
-
 					return true;
 				} else {
 					$order->add_order_note( 'Could not capture Klarna order. ' . $response->get_error_message() . '.' );

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 				2
 			);
 
-			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatability' ) );
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
 		}
 
 		/**
@@ -155,7 +155,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 		 *
 		 * @return void
 		 */
-		public function declare_wc_compatability() {
+		public function declare_wc_compatibility() {
 
 			// Declare HPOS compatibility.
 			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -366,7 +366,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 					return;
 				}
 				// Do nothing if we don't have Klarna order ID.
-				if ( ! $order->get_meta( '_wc_klarna_order_id', true ) && ! $order->get_meta( '_transaction_id', true ) ) {
+				if ( ! $order->get_meta( '_wc_klarna_order_id', true ) && ! $order->get_transaction_id() ) {
 					$order->add_order_note( 'Klarna order ID is missing, Klarna order could not be captured at this time.' );
 					$order->set_status( 'on-hold' );
 					$order->save();


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and `update_meta_data` is still used, WooCommerce will warn about directly modifying internal meta data.

Note:
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.

---
**Issue with refunds:**

This fix addresses an issue where all subsequent refunds, except for the initial one, were failing. The problem arose because the `_wc_klarna_capture_id` field was being overwritten with an empty string during the first refund request. As a result, on subsequent partial refunds, the absence of a value in this field prevented the refund request from being processed. The fix ensures that the `_wc_klarna_capture_id` field retains its original value, allowing subsequent refund requests to proceed successfully.