### PR TITLE
Fix critical error due to missing HPOS-related classes

### DIFF
--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -46,11 +46,20 @@ class WC_Klarna_Meta_Box {
 	 * @return void
 	 */
 	public function kom_meta_box( $post_type ) {
-		$hpos_enabled = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
-		$screen       = $hpos_enabled ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
-		$order_id     = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+		$hpos_enabled = false;
 
-		if ( 'shop_order' === OrderUtil::get_order_type( $order_id ) ) {
+		// CustomOrdersTableController was introduced in WC 6.4.
+		if ( class_exists( 'CustomOrdersTableController' ) ) {
+			$hpos_enabled = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+		}
+
+		$screen   = $hpos_enabled ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		$order_id = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+
+		// OrderUtil was introduced in WC 6.9.
+		$order_type = class_exists( 'OrderUtil' ) ? OrderUtil::get_order_type( $order_id ) : get_post_type( $order_id );
+
+		if ( 'shop_order' === $order_type ) {
 			$order = wc_get_order( $order_id );
 			if ( in_array( $order->get_payment_method(), array( 'kco', 'klarna_payments' ), true ) ) {
 				add_meta_box( 'kom_meta_box', __( 'Klarna Order Management', 'klarna-order-management-for-woocommerce' ), array( $this, 'kom_meta_box_content' ), $screen, 'side', 'core' );
@@ -91,11 +100,11 @@ class WC_Klarna_Meta_Box {
 	 * @return void
 	 */
 	public function print_standard_content( $klarna_order ) {
-		$order_id           = get_the_ID();
-		$order              = wc_get_order( $order_id );
-		$settings           = WC_Klarna_Order_Management::get_instance()->settings->get_settings( $order_id );
-		
-    $actions            = array();
+		$order_id = get_the_ID();
+		$order    = wc_get_order( $order_id );
+		$settings = WC_Klarna_Order_Management::get_instance()->settings->get_settings( $order_id );
+
+		$actions            = array();
 		$actions['capture'] = ( ! isset( $settings['kom_auto_capture'] ) || 'yes' === $settings['kom_auto_capture'] ) ? false : true;
 		$actions['cancel']  = ( ! isset( $settings['kom_auto_cancel'] ) || 'yes' === $settings['kom_auto_cancel'] ) ? false : true;
 		$actions['sync']    = ( ! isset( $settings['kom_auto_order_sync'] ) || 'yes' === $settings['kom_auto_order_sync'] ) ? false : true;

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -9,7 +9,7 @@
  * Text Domain: klarna-order-management-for-woocommerce
  * Domain Path: /languages
  *
- * WC requires at least: 3.4.0
+ * WC requires at least: 5.0.0
  * WC tested up to: 7.7.0
  *
  * Copyright (c) 2018-2023 Krokedil

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: woocommerce, klarna
 Donate link: https://klarna.com
 Requires at least: 4.0
 Tested up to: 6.2
-Requires PHP: 7.0
-WC requires at least: 4.0.0
+Requires PHP: 7.3
+WC requires at least: 5.0.0
 WC tested up to: 7.7.0
 Stable tag: trunk
 License: GPLv3 or later


### PR DESCRIPTION
The `CustomOrdersTableController` class was only introduced in WC 6.4.0 whereas `OrderUtil` was only introduced in WC 6.9.0.

- if `CustomOrdersTableController` does not exist, assume that HPOS is disabled.
- if `OrderUtil` does not exist, use `get_post_type` to check if it the order ID is a `shop_order`.
- bump required WC to 5.0.0.
- bump required PHP to 7.3

Related issue: #93 