### PR TITLE
Version 1.8.1

### DIFF
--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -49,15 +49,12 @@ class WC_Klarna_Meta_Box {
 		$hpos_enabled = false;
 
 		// CustomOrdersTableController was introduced in WC 6.4.
-		if ( class_exists( 'CustomOrdersTableController' ) ) {
+		if ( class_exists( CustomOrdersTableController::class ) ) {
 			$hpos_enabled = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
 		}
 
-		$screen   = $hpos_enabled ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		$screen   = $hpos_enabled ? wc_get_page_screen_id( 'shop-order' ) : $post_type;
 		$order_id = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
-
-		// OrderUtil was introduced in WC 6.9.
-		$order_type = class_exists( 'OrderUtil' ) ? OrderUtil::get_order_type( $order_id ) : get_post_type( $order_id );
 
 		if ( in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order' ) ) ) {
 			$order = wc_get_order( $order_id );

--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -59,7 +59,7 @@ class WC_Klarna_Meta_Box {
 		// OrderUtil was introduced in WC 6.9.
 		$order_type = class_exists( 'OrderUtil' ) ? OrderUtil::get_order_type( $order_id ) : get_post_type( $order_id );
 
-		if ( 'shop_order' === $order_type ) {
+		if ( in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order' ) ) ) {
 			$order = wc_get_order( $order_id );
 			if ( in_array( $order->get_payment_method(), array( 'kco', 'klarna_payments' ), true ) ) {
 				add_meta_box( 'kom_meta_box', __( 'Klarna Order Management', 'klarna-order-management-for-woocommerce' ), array( $this, 'kom_meta_box_content' ), $screen, 'side', 'core' );

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -5,14 +5,14 @@
  * Description: Provides order management for Klarna Payments and Klarna Checkout gateways.
  * Author: klarna, krokedil
  * Author URI: https://krokedil.se/
- * Version: 1.7.1
+ * Version: 1.8.0
  * Text Domain: klarna-order-management-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 3.4.0
  * WC tested up to: 7.7.0
  *
- * Copyright (c) 2018-2022 Krokedil
+ * Copyright (c) 2018-2023 Krokedil
  *
  * @package WC_Klarna_Order_Management
  */
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_ORDER_MANAGEMENT_VERSION', '1.7.1' );
+define( 'WC_KLARNA_ORDER_MANAGEMENT_VERSION', '1.8.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_MIN_PHP_VER', '5.3.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides order management for Klarna Payments and Klarna Checkout gateways.
  * Author: klarna, krokedil
  * Author URI: https://krokedil.se/
- * Version: 1.8.0
+ * Version: 1.8.1
  * Text Domain: klarna-order-management-for-woocommerce
  * Domain Path: /languages
  *
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_ORDER_MANAGEMENT_VERSION', '1.8.0' );
+define( 'WC_KLARNA_ORDER_MANAGEMENT_VERSION', '1.8.1' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_MIN_PHP_VER', '5.3.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,10 @@ Provides post-purchase order management for Klarna Payments for WooCommerce and 
 For help setting up and configuring Klarna Order Management for WooCommerce please refer to our [documentation](https://docs.krokedil.com/article/149-klarna-order-management/).
 
 == Changelog ==
+= 2023.07.04    - version 1.8.1 =
+* Fix           - Resolved a critical error that occurred on older versions of WooCommerce when displaying the metabox.
+* Tweak         - Increased the minimum required PHP version to 7.3 and the minimum required WooCommerce version to 5.0.0.
+
 = 2023.06.20    - version 1.8.0 =
 * Feature       - The plugin now supports WooCommerce's "High-Performance Order Storage" ("HPOS") feature.
 * Tweak         - The plugin settings have been relocated to the payment gateways' plugin settings.

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,13 @@ Provides post-purchase order management for Klarna Payments for WooCommerce and 
 For help setting up and configuring Klarna Order Management for WooCommerce please refer to our [documentation](https://docs.krokedil.com/article/149-klarna-order-management/).
 
 == Changelog ==
+= 2023.06.20    - version 1.8.0 =
+* Feature       - The plugin now supports WooCommerce's "High-Performance Order Storage" ("HPOS") feature.
+* Tweak         - The plugin settings have been relocated to the payment gateways' plugin settings.
+* Fix           - Addressed undefined index notices and resolved a PHP 8 deprecation warning.
+* Fix           - Fixed a critical error that occasionally occurred when logging was enabled.
+
+
 = 2022.12.08    - version 1.7.1 =
 * Tweak         - The remaining authorized amount will now be written to the order note if the capture fails.
 * Tweak         - Better error handling when the request body is missing.


### PR DESCRIPTION
* Fix           - Resolved a critical error that occurred on older versions of WooCommerce when displaying the metabox.
* Tweak         - Increased the minimum required PHP version to 7.3 and the minimum required WooCommerce version to 5.0.0.