### PR TITLE
Retrieve KOM settings from order_id when logging

### DIFF
--- a/classes/class-wc-klarna-logger.php
+++ b/classes/class-wc-klarna-logger.php
@@ -24,10 +24,16 @@ class WC_Klarna_Logger {
 	 * Logs an event.
 	 *
 	 * @param string $data The data string.
-	 * @param array  $settings The plugin settings for the order.
+	 * @param int    $order_id WooCommerce order ID.
 	 */
-	public static function log( $data, $settings ) {
-		if ( ! isset( $settings['kom_debug_log'] ) || 'yes' === $settings['kom_debug_log'] ) {
+	public static function log( $data, $order_id = null ) {
+		// Use default $order_id, and return rather than causing a fatal error if the $order_id is forgotten.
+		if ( empty( $order_id ) || ! class_exists( 'WC_Klarna_Order_Management' ) ) {
+			return;
+		}
+
+		$settings = WC_Klarna_Order_Management::get_instance()->settings->get_settings( $order_id );
+		if ( isset( $settings['kom_debug_log'] ) && 'yes' === $settings['kom_debug_log'] ) {
 			$message = self::format_data( $data );
 			if ( empty( self::$log ) ) {
 				self::$log = new WC_Logger();

--- a/classes/class-wc-klarna-sellers-app.php
+++ b/classes/class-wc-klarna-sellers-app.php
@@ -135,12 +135,13 @@ class WC_Klarna_Sellers_App {
 	 * Processes order lines with order data received from Klarna.
 	 *
 	 * @param Klarna_Checkout_Order $klarna_order Klarna order.
-	 * @param WooCommerce_Order     $order WooCommerce order.
+	 * @param WC_Order              $order WooCommerce order.
 	 *
 	 * @throws Exception WC_Data_Exception.
 	 */
 	private static function process_order_lines( $klarna_order, $order ) {
-		WC_Klarna_Logger::log( 'Processing order lines (from Klarna order) during sellers app creation for Klarna order ID ' . $klarna_order->order_id );
+		$order_id = $order->get_id();
+		WC_Klarna_Logger::log( 'Processing order lines (from Klarna order) during sellers app creation for Klarna order ID ' . $klarna_order->order_id, $order_id );
 		foreach ( $klarna_order->order_lines as $cart_item ) {
 
 			// Only try to add the item to the order if we got a reference in the Klarna order.
@@ -174,7 +175,7 @@ class WC_Klarna_Sellers_App {
 					$order->add_item( $item );
 
 				} catch ( Exception $e ) {
-					WC_Klarna_Logger::log( 'Error during process order lines. Add to cart error:   ' . $e->getCode() . ' - ' . $e->getMessage() );
+					WC_Klarna_Logger::log( 'Error during process order lines. Add to cart error:   ' . $e->getCode() . ' - ' . $e->getMessage(), $order_id );
 				}
 			}
 
@@ -195,7 +196,7 @@ class WC_Klarna_Sellers_App {
 					);
 					$order->add_item( $item );
 				} catch ( Exception $e ) {
-					WC_Klarna_Logger::log( 'Error during process order lines. Add shipping error:   ' . $e->getCode() . ' - ' . $e->getMessage() );
+					WC_Klarna_Logger::log( 'Error during process order lines. Add shipping error:   ' . $e->getCode() . ' - ' . $e->getMessage(), $order_id );
 				}
 			}
 
@@ -217,7 +218,7 @@ class WC_Klarna_Sellers_App {
 					$fee->set_props( $args );
 					$order->add_item( $fee );
 				} catch ( Exception $e ) {
-					WC_Klarna_Logger::log( 'Error during process order lines. Add fee error:   ' . $e->getCode() . ' - ' . $e->getMessage() );
+					WC_Klarna_Logger::log( 'Error during process order lines. Add fee error:   ' . $e->getCode() . ' - ' . $e->getMessage(), $order_id );
 				}
 			}
 		}

--- a/classes/request/class-kom-request.php
+++ b/classes/request/class-kom-request.php
@@ -68,13 +68,15 @@ abstract class KOM_Request {
 	public function __construct( $arguments = array() ) {
 		$this->arguments       = $arguments;
 		$this->order_id        = $arguments['order_id'];
-		$this->settings  	   = $this->get_settings();
+		$this->settings        = $this->get_settings();
 		$this->klarna_order_id = $this->get_klarna_order_id();
 		$this->klarna_order    = array_key_exists( 'klarna_order', $arguments ) ? $arguments['klarna_order'] : false;
 	}
 
 	/**
 	 * Returns the settings for the plugin based on the orders payment method.
+	 *
+	 * @param int $order_id WooCommerce order ID.
 	 *
 	 * @return array
 	 */
@@ -360,13 +362,13 @@ abstract class KOM_Request {
 	/**
 	 * Standardized logging format for requests/responses.
 	 *
-	 * @param object|WP_Error $response The request response.
-	 * @param array           $request_args The arguments of the request.
-	 * @param int             $code The HTTP Response Code this request returned.
+	 * @param array|WP_Error $response The request response.
+	 * @param array          $request_args The arguments of the request.
+	 * @param int            $code The HTTP Response Code this request returned.
 	 * @return void
 	 */
 	protected function log_response( $response, $request_args, $code ) {
 		$log = WC_Klarna_Logger::format_log( $this->klarna_order_id, $this->method, $this->log_title, $request_args, $response, $code );
-		WC_Klarna_Logger::log( $log, $this->settings );
+		WC_Klarna_Logger::log( $log, $this->order_id );
 	}
 }


### PR DESCRIPTION
Currently, we require the KOM settings to determine whether logging is enabled. However, the function for retrieving the settings is only available in the KOM_Request functions while logging like in the case of Klarna Sellers App is happening elsewhere as well. With this change, we'll now use the WC order ID which is more readily available to retrieve the KOM settings rather than directly passing the settings to the logging function.