### PR TITLE
Add option to disconnect the order from the order manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,34 @@
+# Editors
+project.xml
+project.properties
+.buildpath
+.project
+.settings*
+.idea
+.vscode
+.eslintcache
+*.sublime-project
+*.sublime-workspace
+.sublimelinterrc
+*.swp
+
+node_modules/
+
+# OS X metadata
+.DS_Store
+
+# Windows junk
+Thumbs.db
+
+# Logs
+logs
 *.log
-wp-config.php
-wp-content/advanced-cache.php
-wp-content/backup-db/
-wp-content/backups/
-wp-content/blogs.dir/
-wp-content/cache/
-wp-content/upgrade/
-wp-content/uploads/
-wp-content/wp-cache-config.php
-wp-content/plugins/hello.php
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
-/.wp
-/.htaccess
-/license.txt
-/readme.html
-/sitemap.xml
-/sitemap.xml.gz
-/vendor
+/vendor/
 
-SyncToy_33a8f183-90c0-4e98-b583-e741e3e538ea.dat
+# Release
+/release/
+yarn.lock

--- a/assets/css/klarna-order-management.css
+++ b/assets/css/klarna-order-management.css
@@ -1,0 +1,24 @@
+/* METABOX CONNECTION */
+#kom_meta_box .kom_order_sync .kom_order_sync_edit {
+    display: inline-block;
+}
+
+#kom_meta_box .kom_order_sync--box {
+    display: none;
+}
+
+#kom_meta_box .kom_order_sync--toggle {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#kom_meta_box .kom_order_sync--toggle .woocommerce-help-tip {
+    margin: 0;
+}
+
+#kom_meta_box .kom_order_sync--action > .cancel_button {
+    border: none;
+    background: inherit;
+}

--- a/assets/js/klarna-order-management.js
+++ b/assets/js/klarna-order-management.js
@@ -1,0 +1,35 @@
+jQuery( function ( $ ) {
+	$( document ).ready( function () {
+		const kom = {
+			edit_button: $( ".kom_order_sync_edit" ),
+			order_sync_box: $( ".kom_order_sync--box" ),
+			toggle_button: $( ".kom_order_sync--toggle .woocommerce-input-toggle" ),
+			submit_button: $( ".kom_order_sync--action > .submit_button" ),
+			cancel_button: $( ".kom_order_sync--action > .cancel_button" ),
+			sync_status: function () {
+				return kom.toggle_button.hasClass( "woocommerce-input-toggle--enabled" ) ? "enabled" : "disabled"
+			},
+		}
+
+		kom.edit_button.on( "click", function () {
+			if ( "none" !== kom.edit_button.css( "display" ) ) {
+				kom.order_sync_box.fadeIn()
+				kom.edit_button.css( "display", "none" )
+			} else {
+				kom.edit_button.css( "display", "" )
+				kom.order_sync_box.css( "display", "" )
+			}
+		} )
+
+		kom.toggle_button.click( function () {
+			const url = new URL( kom.submit_button.attr( "href" ), window.location )
+			kom.toggle_button.toggleClass( "woocommerce-input-toggle--disabled woocommerce-input-toggle--enabled" )
+			url.searchParams.set( "kom", kom.sync_status() )
+			kom.submit_button.attr( "href", url.toString() )
+		} )
+
+		kom.cancel_button.on( "click", function () {
+			kom.edit_button.click()
+		} )
+	} )
+} )

--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -18,11 +18,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles the meta box for KOM
  */
 class WC_Klarna_Meta_Box {
+
+
 	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
-		add_action( 'add_meta_boxes', array( $this, 'kom_meta_box' ) );
+		 add_action( 'add_meta_boxes', array( $this, 'kom_meta_box' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'process_kom_actions' ), 45, 2 );
 
 		add_filter( 'kom_meta_environment', array( $this, 'filter_environment' ), 10, 1 );
@@ -101,19 +103,18 @@ class WC_Klarna_Meta_Box {
 		$kom_disconnected_status = __( 'Disconnect', 'klarna-order-management-for-woocommerce' );
 		if ( isset( $_GET['kom'] ) && isset( $_GET[ $kom_disconnected_key ] ) && wp_verify_nonce( $_GET[ $kom_disconnected_key ], 'kom_disconnect' ) ) {
 			$action = sanitize_text_field( (string) wp_unslash( $_GET['kom'] ) );
-			if ( 'connect' === $action ) {
+			if ( 'enabled' === $action ) {
 				$order->delete_meta_data( $kom_disconnected_key );
-			} elseif ( 'disconnect' === $action ) {
+			} elseif ( 'disabled' === $action ) {
 				$order->update_meta_data( $kom_disconnected_key, 1 );
 			}
 			$order->save();
-
 		}
 
 		if ( $order->get_meta( $kom_disconnected_key ) ) {
-			$kom_disconnected_status = __( 'Connect', 'klarna-order-management-for-woocommerce' );
+			$kom_disconnected_status = 'disabled';
 		} else {
-			$kom_disconnected_status = __( 'Disconnect', 'klarna-order-management-for-woocommerce' );
+			$kom_disconnected_status = 'enabled';
 		}
 
 		$kom_disconnected_url = add_query_arg(
@@ -128,28 +129,39 @@ class WC_Klarna_Meta_Box {
 			<?php do_action( 'kom_meta_begin' ); ?>
 			<?php if ( $klarna_order ) : ?>
 
-				<strong><?php esc_html_e( 'Klarna Environment: ', 'klarna-order-management-for-woocommerce' ); ?></strong>
-				<?php echo( esc_html( apply_filters( 'kom_meta_environment', $environment ) ) ); ?><br/>
+				<strong>
+					<?php esc_html_e( 'Klarna Environment: ', 'klarna-order-management-for-woocommerce' ); ?>
+				</strong>
+				<?php echo ( esc_html( apply_filters( 'kom_meta_environment', $environment ) ) ); ?><br />
 
-				<strong><?php esc_html_e( 'Klarna order status: ', 'klarna-order-management-for-woocommerce' ); ?></strong>
-				<?php echo( esc_html( apply_filters( 'kom_meta_order_status', $klarna_order->status ) ) ); ?><br/>
+				<strong>
+					<?php esc_html_e( 'Klarna order status: ', 'klarna-order-management-for-woocommerce' ); ?>
+				</strong>
+				<?php echo ( esc_html( apply_filters( 'kom_meta_order_status', $klarna_order->status ) ) ); ?><br />
 
-				<strong><?php esc_html_e( 'Initial Payment method: ', 'klarna-order-management-for-woocommerce' ); ?></strong>
-				<?php echo( esc_html( apply_filters( 'kom_meta_payment_method', $klarna_order->initial_payment_method->description ) ) ); ?></br>
+				<strong>
+					<?php esc_html_e( 'Initial Payment method: ', 'klarna-order-management-for-woocommerce' ); ?>
+				</strong>
+				<?php echo ( esc_html( apply_filters( 'kom_meta_payment_method', $klarna_order->initial_payment_method->description ) ) ); ?></br>
 
 				<ul class="kom_order_actions_wrapper submitbox">
 					<?php if ( $actions['any'] ) : ?>
 						<li class="wide" id="kom-capture">
 							<select class="kco_order_actions" name="kom_order_actions" id="kom_order_actions">
-								<option value=""><?php echo esc_attr( __( 'Choose an action...', 'woocommerce' ) ); ?></option>
+								<option value="">
+									<?php echo esc_attr( __( 'Choose an action...', 'woocommerce' ) ); ?>
+								</option>
 								<?php do_action( 'kom_meta_action_options', $order_id, $klarna_order, $actions ); ?>
 							</select>
-							<button class="button wc-reload"><span><?php esc_html_e( 'Apply', 'woocommerce' ); ?></span></button>
-							<span class="woocommerce-help-tip" data-tip="<?php do_action( 'kom_meta_action_tips', $order_id, $klarna_order, $actions ); ?>"></span>
+							<button class="button wc-reload"><span>
+									<?php esc_html_e( 'Apply', 'woocommerce' ); ?>
+								</span></button>
+							<span class="woocommerce-help-tip"
+								data-tip="<?php do_action( 'kom_meta_action_tips', $order_id, $klarna_order, $actions ); ?>"></span>
 						</li>
 					<?php else : ?>
 						<?php do_action( 'kom_meta_no_actions', $order_id, $klarna_order, $actions ); ?>
-					<?php endif; ?>	
+					<?php endif; ?>
 				</ul>
 
 
@@ -158,14 +170,34 @@ class WC_Klarna_Meta_Box {
 				<ul class="kom_order_actions_wrapper submitbox">
 					<?php do_action( 'kom_meta_uncaptured_begin' ); ?>
 					<li class="wide" id="kom-capture">
-						<input type="text" id="klarna_order_id" name="klarna_order_id" class="klarna_order_id" placeholder="Klarna order ID">
-						<button class="button wc-reload"><span><?php esc_html_e( 'Apply', 'woocommerce' ); ?></span></button>
+						<input type="text" id="klarna_order_id" name="klarna_order_id" class="klarna_order_id"
+							placeholder="Klarna order ID">
+						<button class="button wc-reload"><span>
+								<?php esc_html_e( 'Apply', 'woocommerce' ); ?>
+							</span></button>
 					</li>
 					<?php do_action( 'kom_meta_uncaptured_end' ); ?>
 				</ul>
 			<?php endif; ?>
 
-			<a href="<?php echo esc_url( wp_nonce_url( $kom_disconnected_url, 'kom_disconnect', $kom_disconnected_key ) ); ?>"><button type="button" class="button button-primary"><?php echo esc_html( $kom_disconnected_status ); ?></button></a>
+			<div class="kom_order_sync">
+				<div class="kom_order_sync--box">
+					<div class="kom_order_sync--toggle">
+						<p><label>Order synchronization
+								<?php echo wc_help_tip( __( 'Disable this to turn off the automatic synchronization with the Klarna Merchant Portal. When disabled, any changes in either system have to be done manually.', 'klarna-order-management-for-woocommerce' ) ); ?>
+							</label></p>
+						<span
+							class="woocommerce-input-toggle woocommerce-input-toggle--<?php echo esc_attr( $kom_disconnected_status ); ?>">
+					</div>
+					<div class="kom_order_sync--action">
+						<a class="button submit_button"
+							href="<?php echo esc_url( wp_nonce_url( $kom_disconnected_url, 'kom_disconnect', $kom_disconnected_key ) ); ?>">
+								<?php esc_attr_e( 'OK' ); ?></a>
+						<a class="button cancel_button">Cancel</a>
+					</div>
+				</div>
+				<a class="kom_order_sync_edit" href="#">Edit</a>
+			</div>
 			<?php do_action( 'kom_meta_end' ); ?>
 		</div>
 		<?php
@@ -357,7 +389,9 @@ class WC_Klarna_Meta_Box {
 	public function print_error_content( $message ) {
 		?>
 		<div class="kom-meta-box-content">
-			<p><?php echo esc_html( $message ); ?></p>
+			<p>
+				<?php echo esc_html( $message ); ?>
+			</p>
 		</div>
 		<?php
 	}
@@ -402,4 +436,5 @@ class WC_Klarna_Meta_Box {
 			WC_Klarna_Sellers_App::populate_klarna_order( $post_id, $klarna_order );
 		}
 	}
-} new WC_Klarna_Meta_Box();
+}
+new WC_Klarna_Meta_Box();

--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -99,16 +99,15 @@ class WC_Klarna_Meta_Box {
 		$environment        = ! empty( $order->get_meta( '_wc_klarna_environment' ) ) ? $order->get_meta( '_wc_klarna_environment' ) : '';
 
 		// Release/Disconnect.
-		$kom_disconnected_key    = '_kom_disconnect';
-		$kom_disconnect          = isset( $_GET[ $kom_disconnected_key ] ) ? sanitize_key( $_GET[ $kom_disconnected_key ] ) : false;
-		$kom_disconnected_status = __( 'Disconnect', 'klarna-order-management-for-woocommerce' );
+		$kom_disconnected_key = '_kom_disconnect';
+		$kom_disconnect       = isset( $_GET[ $kom_disconnected_key ] ) ? sanitize_key( $_GET[ $kom_disconnected_key ] ) : false;
 
 		if ( isset( $_GET['kom'] ) && wp_verify_nonce( $kom_disconnect, 'kom_disconnect' ) ) {
 			$action = sanitize_text_field( wp_unslash( $_GET['kom'] ) );
 			// Disabled mean it is disconnected, not that the feature is disabled.
 			if ( 'disabled' === $action ) {
 				$order->update_meta_data( $kom_disconnected_key, 1 );
-			} elseif ( 'disabled' === $action ) {
+			} elseif ( 'enabled' === $action ) {
 				$order->delete_meta_data( $kom_disconnected_key );
 			}
 			$order->save();

--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -108,6 +108,31 @@ class WC_Klarna_Meta_Box {
 		$actions['any']     = ( $actions['capture'] || $actions['cancel'] || $actions['sync'] );
 		$environment        = ! empty( $order->get_meta( '_wc_klarna_environment', true ) ) ? $order->get_meta( '_wc_klarna_environment', true ) : '';
 
+		$kom_disconnected_key    = '_kom_disconnect';
+		$kom_disconnected_status = __( 'Disconnect', 'klarna-order-management-for-woocommerce' );
+		if ( isset( $_GET['kom'] ) ) {
+			if ( 'connect' === $_GET['kom'] ) {
+				$order->delete_meta_data( $kom_disconnected_key );
+			} elseif ( 'disconnect' === $_GET['kom'] ) {
+				$order->update_meta_data( $kom_disconnected_key, 1 );
+			}
+			$order->save();
+
+		}
+
+		if ( $order->get_meta( $kom_disconnected_key ) ) {
+			$kom_disconnected_status = __( 'Connect', 'klarna-order-management-for-woocommerce' );
+		} else {
+			$kom_disconnected_status = __( 'Disconnect', 'klarna-order-management-for-woocommerce' );
+		}
+
+		$kom_disconnected_url = add_query_arg(
+			array(
+				'kom' => strtolower( $kom_disconnected_status ),
+			),
+			admin_url( 'post.php?post=' . absint( $order->id ) . '&action=edit' )
+		);
+
 		?>
 		<div class="kom-meta-box-content">
 			<?php do_action( 'kom_meta_begin' ); ?>
@@ -137,6 +162,7 @@ class WC_Klarna_Meta_Box {
 					<?php endif; ?>	
 				</ul>
 
+
 			<?php else : ?>
 
 				<ul class="kom_order_actions_wrapper submitbox">
@@ -150,6 +176,7 @@ class WC_Klarna_Meta_Box {
 			<?php endif; ?>
 
 			<?php do_action( 'kom_meta_end' ); ?>
+			<a href="<?php echo esc_url( $kom_disconnected_url ); ?>"><button type="button" class="button button-primary"><?php echo esc_html( $kom_disconnected_status ); ?></button></a>
 		</div>
 		<?php
 	}

--- a/classes/class-wc-klarna-meta-box.php
+++ b/classes/class-wc-klarna-meta-box.php
@@ -43,7 +43,7 @@ class WC_Klarna_Meta_Box {
 	 * @return void
 	 */
 	public function kom_meta_box( $post_type ) {
-		if ( in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order' ) ) ) {
+		if ( in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order', true ) ) ) {
 			$order_id = kom_get_the_ID();
 			$order    = wc_get_order( $order_id );
 			if ( in_array( $order->get_payment_method(), array( 'kco', 'klarna_payments' ), true ) ) {
@@ -99,10 +99,11 @@ class WC_Klarna_Meta_Box {
 		// Release/Disconnect.
 		$kom_disconnected_key    = '_kom_disconnect';
 		$kom_disconnected_status = __( 'Disconnect', 'klarna-order-management-for-woocommerce' );
-		if ( isset( $_GET['kom'] ) ) {
-			if ( 'connect' === $_GET['kom'] ) {
+		if ( isset( $_GET['kom'] ) && isset( $_GET[ $kom_disconnected_key ] ) && wp_verify_nonce( $_GET[ $kom_disconnected_key ], 'kom_disconnect' ) ) {
+			$action = sanitize_text_field( (string) wp_unslash( $_GET['kom'] ) );
+			if ( 'connect' === $action ) {
 				$order->delete_meta_data( $kom_disconnected_key );
-			} elseif ( 'disconnect' === $_GET['kom'] ) {
+			} elseif ( 'disconnect' === $action ) {
 				$order->update_meta_data( $kom_disconnected_key, 1 );
 			}
 			$order->save();
@@ -164,8 +165,8 @@ class WC_Klarna_Meta_Box {
 				</ul>
 			<?php endif; ?>
 
+			<a href="<?php echo esc_url( wp_nonce_url( $kom_disconnected_url, 'kom_disconnect', $kom_disconnected_key ) ); ?>"><button type="button" class="button button-primary"><?php echo esc_html( $kom_disconnected_status ); ?></button></a>
 			<?php do_action( 'kom_meta_end' ); ?>
-			<a href="<?php echo esc_url( $kom_disconnected_url ); ?>"><button type="button" class="button button-primary"><?php echo esc_html( $kom_disconnected_status ); ?></button></a>
 		</div>
 		<?php
 	}

--- a/classes/class-wc-klarna-order-management-settings.php
+++ b/classes/class-wc-klarna-order-management-settings.php
@@ -84,6 +84,14 @@ class WC_Klarna_Order_Management_Settings {
 		return $settings;
 	}
 
+	/**
+	 * Retrieve the plugin settings.
+	 *
+	 * If the plugin's settings could not be found, we'll default to KP's or KCO's settings depending on the payment method.
+	 *
+	 * @param int $order_id WooCommerce order ID.
+	 * @return array|false
+	 */
 	public function get_settings( $order_id ) {
 		if ( empty( $order_id ) ) {
 			/* If "kom_settings" is not available, use default values. */

--- a/classes/request/class-kom-request.php
+++ b/classes/request/class-kom-request.php
@@ -68,15 +68,13 @@ abstract class KOM_Request {
 	public function __construct( $arguments = array() ) {
 		$this->arguments       = $arguments;
 		$this->order_id        = $arguments['order_id'];
-		$this->settings  	   = $this->get_settings();
+		$this->settings        = $this->get_settings();
 		$this->klarna_order_id = $this->get_klarna_order_id();
 		$this->klarna_order    = array_key_exists( 'klarna_order', $arguments ) ? $arguments['klarna_order'] : false;
 	}
 
 	/**
 	 * Returns the settings for the plugin based on the orders payment method.
-	 *
-	 * @return array
 	 */
 	private function get_settings() {
 		return WC_Klarna_Order_Management::get_instance()->settings->get_settings( $this->order_id );

--- a/includes/klarna-order-management-functions.php
+++ b/includes/klarna-order-management-functions.php
@@ -44,7 +44,7 @@ function kom_is_hpos_enabled() {
 /**
  * Get the product and its image URLs.
  *
- * @param WC_Order_Item_Product The order item.
+ * @param WC_Order_Item_Product $item The order item.
  * @return array The product and image URL if available, otherwise an empty array.
  */
 function kom_maybe_add_product_urls( $item ) {

--- a/includes/klarna-order-management-functions.php
+++ b/includes/klarna-order-management-functions.php
@@ -9,6 +9,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
+/**
+ * Equivalent to WP's get_the_ID() with HPOS support.
+ *
+ * @return int the order ID or false.
+ */
+//phpcs:ignore
+function kom_get_the_ID() {
+	$hpos_enabled = kom_is_hpos_enabled();
+	$order_id     = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+	if ( empty( $order_id ) ) {
+		return false;
+	}
+
+	return $order_id;
+}
+
+/**
+ * Whether HPOS is enabled.
+ *
+ * @return bool
+ */
+function kom_is_hpos_enabled() {
+	// CustomOrdersTableController was introduced in WC 6.4.
+	if ( class_exists( CustomOrdersTableController::class ) ) {
+		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+	}
+
+	return false;
+}
+
 /**
  * Get the product and its image URLs.
  *

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -28,6 +28,7 @@ define( 'WC_KLARNA_ORDER_MANAGEMENT_VERSION', '1.8.1' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_MIN_PHP_VER', '5.3.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_ORDER_MANAGEMENT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
+define( 'WC_KLARNA_ORDER_MANAGEMENT_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 
 if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 
@@ -147,7 +148,20 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 
 			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
 			$this->settings = new WC_Klarna_Order_Management_Settings();
+
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin' ) );
 		}
+
+		/**
+		 * Register and enqueue scripts for the admin.
+		 *
+		 * @return void
+		 */
+		public function enqueue_admin() {
+			wp_enqueue_style( 'kom-admin-style', WC_KLARNA_ORDER_MANAGEMENT_CHECKOUT_URL . '/assets/css/klarna-order-management.css', array(), WC_KLARNA_ORDER_MANAGEMENT_VERSION );
+			wp_enqueue_script( 'kom-admin-js', WC_KLARNA_ORDER_MANAGEMENT_CHECKOUT_URL . '/assets/js/klarna-order-management.js', array( 'jquery' ), WC_KLARNA_ORDER_MANAGEMENT_VERSION );
+		}
+
 
 		/**
 		 * Declare compatibility with WooCommerce features.

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -159,7 +159,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 		 */
 		public function enqueue_admin() {
 			wp_enqueue_style( 'kom-admin-style', WC_KLARNA_ORDER_MANAGEMENT_CHECKOUT_URL . '/assets/css/klarna-order-management.css', array(), WC_KLARNA_ORDER_MANAGEMENT_VERSION );
-			wp_enqueue_script( 'kom-admin-js', WC_KLARNA_ORDER_MANAGEMENT_CHECKOUT_URL . '/assets/js/klarna-order-management.js', array( 'jquery' ), WC_KLARNA_ORDER_MANAGEMENT_VERSION );
+			wp_enqueue_script( 'kom-admin-js', WC_KLARNA_ORDER_MANAGEMENT_CHECKOUT_URL . '/assets/js/klarna-order-management.js', array( 'jquery' ), WC_KLARNA_ORDER_MANAGEMENT_VERSION, true );
 		}
 
 

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -209,6 +209,11 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 			if ( ! isset( $options['kom_auto_cancel'] ) || 'yes' === $options['kom_auto_cancel'] || $action ) {
 				$order = wc_get_order( $order_id );
 
+				// The merchant has disconnected the order from the order manager.
+				if ( $order->get_meta( '_kom_disconnect' ) ) {
+					return;
+				}
+
 				// Check if the order has been paid.
 				if ( empty( $order->get_date_paid() ) ) {
 					return;
@@ -277,6 +282,11 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 
 				$order = wc_get_order( $order_id );
 
+				// The merchant has disconnected the order from the order manager.
+				if ( $order->get_meta( '_kom_disconnect' ) ) {
+					return;
+				}
+
 					// Check if the order has been paid.
 				if ( empty( $order->get_date_paid() ) ) {
 					return;
@@ -340,6 +350,11 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 			$options = self::get_instance()->settings->get_settings( $order_id );
 			if ( ! isset( $options['kom_auto_capture'] ) || 'yes' === $options['kom_auto_capture'] || $action ) {
 				$order = wc_get_order( $order_id );
+
+				// The merchant has disconnected the order from the order manager.
+				if ( $order->get_meta( '_kom_disconnect' ) ) {
+					return;
+				}
 
 					// Check if the order has been paid.
 				if ( empty( $order->get_date_paid() ) ) {
@@ -454,6 +469,10 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 		 */
 		public function refund_klarna_order( $result, $order_id, $amount = null, $reason = '' ) {
 			$order = wc_get_order( $order_id );
+			// The merchant has disconnected the order from the order manager.
+			if ( $order->get_meta( '_kom_disconnect' ) ) {
+				return true;
+			}
 
 			// Not going to do this for non-KP and non-KCO orders.
 			if ( ! in_array(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "klarna-order-management-for-woocommerce",
+  "version": "1.8.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "klarna-order-management-for-woocommerce",
+      "version": "1.8.3",
+      "license": "GPL-3.0+",
+      "devDependencies": {
+        "prettier": "npm:wp-prettier@^3.0.3"
+      }
+    },
+    "node_modules/prettier": {
+      "name": "wp-prettier",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+      "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "klarna-order-management-for-woocommerce",
+  "version": "1.8.3",
+  "description": "Provides order management via Klarna API for Klarna Payments for WooCommerce plugin.",
+  "scripts": {
+    "prettier-js": "npx prettier assets/js --paren-spacing --tab-width 4 --print-width 120 --no-semi --write"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/krokedil/klarna-order-management-for-woocommerce.git"
+  },
+  "author": "Krokedil AB",
+  "license": "GPL-3.0+",
+  "bugs": {
+    "url": "https://github.com/krokedil/klarna-order-management-for-woocommerce/issues"
+  },
+  "homepage": "https://github.com/krokedil/klarna-order-management-for-woocommerce#readme",
+  "devDependencies": {
+    "prettier": "npm:wp-prettier@^3.0.3"
+  }
+}


### PR DESCRIPTION
While the order is disconnected, all order status updates will be ignored, including changing order items.

Related task: https://app.clickup.com/t/865bh2k2v

![image](https://github.com/krokedil/klarna-order-management-for-woocommerce/assets/26507935/d5d21e12-2e30-42c4-8b35-1e94a9bffc1b)
![image](https://github.com/krokedil/klarna-order-management-for-woocommerce/assets/26507935/f85a32f9-19ed-4ca6-abd1-e06cf1db527b)
![image](https://github.com/krokedil/klarna-order-management-for-woocommerce/assets/26507935/6aec3a48-8535-49ea-ba60-2eba3922ccd3)