### PR TITLE
Fix: Refund of orders which contain items that were deleted cause 500

### DIFF
--- a/classes/request/post/class-kom-request-post-refund.php
+++ b/classes/request/post/class-kom-request-post-refund.php
@@ -106,7 +106,7 @@ class KOM_Request_Post_Refund extends KOM_Request_Post {
 						if ( $item->get_product_id() === $order_item->get_product_id() ) {
 							$order_line_total    = round( ( $order->get_line_subtotal( $order_item, false ) * 100 ) );
 							$order_line_tax      = round( ( $order->get_line_tax( $order_item ) * 100 ) );
-							$order_line_tax_rate = ( 0 !== $order_line_tax && 0 !== $order_line_total ) ? reset( WC_Tax::get_base_tax_rates( $product->get_tax_class() ) )['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) : 0;
+							$order_line_tax_rate = ( 0 !== $order_line_tax && 0 !== $order_line_total ) ? reset( WC_Tax::get_base_tax_rates( $order_item->get_tax_class() ) )['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) : 0;
 						}
 					}
 

--- a/includes/klarna-order-management-functions.php
+++ b/includes/klarna-order-management-functions.php
@@ -20,6 +20,7 @@ function kom_maybe_add_product_urls( $item ) {
 	$settings     = get_option( 'woocommerce_kco_settings', array() );
 	if ( isset( $settings['send_product_urls'] ) && 'yes' === $settings['send_product_urls'] ) {
 		$product = wc_get_product( $item->get_product_id() );
+		if(!$product || !is_object($product) || !method_exists($product,'get_image_id')){return $product_data;}
 		if ( $product->get_image_id() > 0 ) {
 			$image_id                  = $product->get_image_id();
 			$image_url                 = wp_get_attachment_image_url( $image_id, 'shop_single', false );

--- a/includes/klarna-order-management-functions.php
+++ b/includes/klarna-order-management-functions.php
@@ -20,7 +20,9 @@ function kom_maybe_add_product_urls( $item ) {
 	$settings     = get_option( 'woocommerce_kco_settings', array() );
 	if ( isset( $settings['send_product_urls'] ) && 'yes' === $settings['send_product_urls'] ) {
 		$product = wc_get_product( $item->get_product_id() );
-		if(!$product || !is_object($product) || !method_exists($product,'get_image_id')){return $product_data;}
+		if(!$product || !is_object($product) || !method_exists($product,'get_image_id')){
+			return $product_data;
+		}
 		if ( $product->get_image_id() > 0 ) {
 			$image_id                  = $product->get_image_id();
 			$image_url                 = wp_get_attachment_image_url( $image_id, 'shop_single', false );


### PR DESCRIPTION

While looping through refunded items script tries to obtain tax class from a product - which might be boolean - which causes a crash. Use get_tax_class() Method oder $order_item instead to prevent crashes.