### PR TITLE
Run init on instance

### DIFF
--- a/classes/class-wc-klarna-order-management-settings.php
+++ b/classes/class-wc-klarna-order-management-settings.php
@@ -96,7 +96,7 @@ class WC_Klarna_Order_Management_Settings {
 	 * If the plugin's settings could not be found, we'll default to KP's or KCO's settings depending on the payment method.
 	 *
 	 * @param int $order_id WooCommerce order ID.
-	 * @return array|false
+	 * @return array|false The plugin settings for the identified Klarna payment gateway or false.
 	 */
 	public function get_settings( $order_id ) {
 		if ( empty( $order_id ) ) {
@@ -104,9 +104,9 @@ class WC_Klarna_Order_Management_Settings {
 			return get_option(
 				'kom_settings',
 				array_map(
-					function( $setting ) {
+					function ( $setting ) {
 						if ( 'title' === $setting['type'] || ! isset( $setting['default'] ) ) {
-							return null;
+							return false;
 						}
 
 						return $setting['default'];
@@ -116,7 +116,13 @@ class WC_Klarna_Order_Management_Settings {
 			);
 		}
 
-		$order          = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
+
+		// Check if we have an order. Usually, we should always have one, however, if this function is called through a snippet, the order id might be retrieved incorrectly.
+		if ( empty( $order ) ) {
+			return false;
+		}
+
 		$payment_method = $order->get_payment_method();
 
 		if ( 'kco' === $payment_method ) {

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -54,16 +54,16 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 		/**
 		 * Returns the *Singleton* instance of this class.
 		 *
-		 * @return self The *Singleton* instance.
+		 * @return self|null The *Singleton* instance. The function may return null if it is called before plugins_loaded action.
 		 */
 		public static function get_instance() {
-			if ( null === self::$instance ) {
-				self::$instance = new self();
+			if ( ! did_action( 'plugins_loaded' ) ) {
+				wc_doing_it_wrong( __FUNCTION__, 'This function should not be called before plugins_loaded.', '1.9.2' );
+				return;
 			}
 
-			// If called through a snippet, the init() call may not have been invoked yet, rendering certain properties null (such as the settings).
-			if ( ! isset( self::$instance->settings ) ) {
-				self::$instance->init();
+			if ( null === self::$instance ) {
+				self::$instance = new self();
 			}
 
 			return self::$instance;

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -61,6 +61,11 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 				self::$instance = new self();
 			}
 
+			// If called through a snippet, the init() call may not have been invoked yet, rendering certain properties null (such as the settings).
+			if ( ! isset( self::$instance->settings ) ) {
+				self::$instance->init();
+			}
+
 			return self::$instance;
 		}
 


### PR DESCRIPTION
If `get_instance()` is called through a snippet, the `init()` call may not have been invoked yet, rendering certain properties null (such as the settings) which will lead to a critical error.

https://app.clickup.com/t/8694y9mwd