### PR TITLE
Handle updating recurring token from KP and KCO

### DIFF
--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -334,7 +334,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 					return new \WP_Error( 'order_sync_off', 'Order synchronization is disabled' );
 				}
 
-					// Check if the order has been paid.
+				// Check if the order has been paid.
 				if ( empty( $order->get_date_paid() ) ) {
 					return new \WP_Error( 'not_paid', 'Order has not been paid.' );
 				}

--- a/klarna-order-management-for-woocommerce.php
+++ b/klarna-order-management-for-woocommerce.php
@@ -303,7 +303,7 @@ if ( ! class_exists( 'WC_Klarna_Order_Management' ) ) {
 			}
 
 			// Are we on the subscription page?
-			if ( wcs_is_subscription( $order ) ) {
+			if ( 'shop_subscription' === $order->get_type() ) {
 				$token_key = 'klarna_payments' === $order->get_payment_method() ? KP_Subscription::RECURRING_TOKEN : '_kco_recurring_token';
 
 				// Did the customer update the subscription's recurring token?


### PR DESCRIPTION
When the merchant updates the recurring token field on the subscription page, we should save this new value to the subscription order's metadata so that it can be used for renewal.


https://app.clickup.com/t/869582bjh