### PR TITLE
Add dev zip GitHub action & changed pnpx to npx in build script

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,8 @@
 /.github
 /node_modules
 /tests
+/vendor
+/languages
 .editorconfig
 .distignore
 .gitignore

--- a/.github/workflows/create-dev-zip.yml
+++ b/.github/workflows/create-dev-zip.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         sed -i "s/^ \* Version: \(.*\)/ \* Version: \1-dev.${BRANCH_NAME}.${COMMIT_HASH}/" ${{ env.PLUGIN_SLUG }}.php
         mkdir -p dev-zip-temp/${{ env.PLUGIN_SLUG }}
-        rsync -av --exclude-from='.kernlignore' --exclude='dev-zip-temp' . dev-zip-temp/${{ env.PLUGIN_SLUG }}
+        rsync -av --exclude-from='.distignore' --exclude='dev-zip-temp' . dev-zip-temp/${{ env.PLUGIN_SLUG }}
         cd dev-zip-temp
         zip -r ../${{ env.ZIP_FILE_NAME }} ${{ env.PLUGIN_SLUG }}
 

--- a/.github/workflows/create-dev-zip.yml
+++ b/.github/workflows/create-dev-zip.yml
@@ -1,9 +1,6 @@
 name: Create Dev Zip
 
 on:
-  push:
-    branches:
-      - '**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create-dev-zip.yml
+++ b/.github/workflows/create-dev-zip.yml
@@ -1,0 +1,77 @@
+name: Create Dev Zip
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      PLUGIN_SLUG: qliro-one-for-woocommerce
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Create composer cache directory
+      run: mkdir -p ~/.composer/cache
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.composer/cache
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Cache npm dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
+
+    - name: Install dependencies and build project
+      run: |
+        mkdir -p ~/.composer/cache
+        composer install --prefer-dist --no-progress
+        npm ci && npm run build
+
+    - name: Get branch name and commit hash
+      id: vars
+      run: |
+        BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+        COMMIT_HASH=$(git rev-parse --short HEAD)
+        ZIP_FILE_NAME="${{ env.PLUGIN_SLUG }}-dev-${BRANCH_NAME}-${COMMIT_HASH}.zip"
+        echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
+        echo "COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
+        echo "ZIP_FILE_NAME=${ZIP_FILE_NAME}" >> $GITHUB_ENV
+
+    - name: Modify version, prepare zip directory, and create zip file
+      run: |
+        sed -i "s/^ \* Version: \(.*\)/ \* Version: \1-dev.${BRANCH_NAME}.${COMMIT_HASH}/" ${{ env.PLUGIN_SLUG }}.php
+        mkdir -p dev-zip-temp/${{ env.PLUGIN_SLUG }}
+        rsync -av --exclude-from='.kernlignore' --exclude='dev-zip-temp' . dev-zip-temp/${{ env.PLUGIN_SLUG }}
+        cd dev-zip-temp
+        zip -r ../${{ env.ZIP_FILE_NAME }} ${{ env.PLUGIN_SLUG }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_KROKEDIL_PLUGIN_DEV_ZIP }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_KROKEDIL_PLUGIN_DEV_ZIP }}
+        aws-region: eu-north-1
+
+    - name: Upload to S3
+      run: |
+        aws s3 cp ${{ env.ZIP_FILE_NAME }} s3://krokedil-plugin-dev-zip/${{ env.ZIP_FILE_NAME }}
+
+    - name: Add annotation to workflow run with dev zip url
+      run: echo "::notice::Dev Zip Url available for 30 days, https://krokedil-plugin-dev-zip.s3.eu-north-1.amazonaws.com/${{ env.ZIP_FILE_NAME }}"

--- a/.github/workflows/create-dev-zip.yml
+++ b/.github/workflows/create-dev-zip.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PLUGIN_SLUG: qliro-one-for-woocommerce
+      PLUGIN_SLUG: klarna-order-management-for-woocommerce
 
     steps:
     - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides order management via Klarna API for Klarna Payments for WooCommerce plugin.",
   "scripts": {
     "prettier-js": "npx prettier assets/js --paren-spacing --tab-width 4 --print-width 120 --no-semi --write",
-    "build": "npm run prettier-js && npx grunt makepot && pnpx grunt cssmin"
+    "build": "npm run prettier-js && npx grunt makepot && npx grunt cssmin"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With this GitHub action workflow you will be able to trigger a manual workflow to create a dev version from a specific branch of the plugin that then will be uploaded to Amazon S3 and later available through a public url for 30 days that can be shared internally or externally if needed.