### PR TITLE
Use variable for reset()

### DIFF
--- a/classes/request/post/class-kom-request-post-refund.php
+++ b/classes/request/post/class-kom-request-post-refund.php
@@ -107,7 +107,8 @@ class KOM_Request_Post_Refund extends KOM_Request_Post {
 							$order_line_total    = round( ( $order->get_line_subtotal( $order_item, false ) * 100 ) );
 							$order_line_tax      = round( ( $order->get_line_tax( $order_item ) * 100 ) );
 							$tax_rates           = WC_Tax::get_base_tax_rates( $order_item->get_tax_class() );
-							$order_line_tax_rate = ( 0 !== $order_line_tax && 0 !== $order_line_total ) ? reset( $tax_rates )['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) : 0;
+							$first_tax_rate      = reset( $tax_rates );
+							$order_line_tax_rate = ( 0 !== $order_line_tax && 0 !== $order_line_total ) ? ( $first_tax_rate['rate'] * 100 ?? round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) ) : 0;
 						}
 					}
 


### PR DESCRIPTION
Use variable for reset(), to resolve PHP notice "Only variables should be passed by reference"