### PR TITLE
Switch API domain for Kustom onboarded merchants

### DIFF
--- a/classes/request/class-kom-request.php
+++ b/classes/request/class-kom-request.php
@@ -147,21 +147,35 @@ abstract class KOM_Request {
 	/**
 	 * Get the domain to use for the request based on the merchant ID.
 	 *
-	 * @param string $merchant_id The Klarna merchant ID.
+	 * @param string $password The shared secret or password to check.
+	 * @param string $username The merchant ID or username to check.
 	 * @param string $klarna_variant The Klarna variant to use (e.g., 'klarna_payments', 'kco').
 	 *
 	 * @return string The domain to use for the request.
 	 */
-	public static function get_api_domain( $merchant_id, $klarna_variant = 'klarna_payments' ) {
+	public static function get_api_domain( $password, $username, $klarna_variant = 'klarna_payments' ) {
 		// If the klarna variant is not kco, just return the Klarna domain.
 		if ( 'kco' !== $klarna_variant ) {
 			return 'klarna.com';
 		}
 
-		// If the merchant ID starts with either M or PM, we need to use the Kustom.
-		$pattern = '/^(M|PM)/';
-		$domain = preg_match( $pattern, $merchant_id ) ? 'kustom.co' : 'klarna.com';
-		return apply_filters( 'kco_api_domain', $domain );
+		// If the password starts with 'kco_', or the mid starts with 'M' or 'PM', use kustom.co, otherwise use klarna.com.
+		$password_pattern = '/^kco_/';
+		$mid_pattern = '/^(M|PM)/';
+
+		$domain = 'klarna.com';
+		if ( preg_match( $password_pattern, $password ) || preg_match( $mid_pattern, $username ) ) {
+			$domain = 'kustom.co';
+		}
+
+		$domain = apply_filters( 'kco_api_domain', $domain, $username );
+
+		// Ensure the return domain is a valid string, and remove any leading or trailing whitespace or slashes.
+		if ( ! is_string( $domain ) || empty( $domain ) ) {
+			$domain = 'klarna.com';
+		}
+
+		return trim( $domain, " \t\n\r\0\x0B/" );
 	}
 
 	/**
@@ -172,7 +186,7 @@ abstract class KOM_Request {
 	protected function get_api_url_base() {
 		$region     = strtolower( apply_filters( 'klarna_base_region', $this->get_klarna_api_region() ) );
 		$playground = $this->use_playground() ? '.playground' : '';
-		$domain     = self::get_api_domain( $this->get_auth_component( 'merchant_id' ), $this->get_klarna_variant() );
+		$domain     = self::get_api_domain( $this->get_auth_component( 'shared_secret' ), $this->get_auth_component( 'merchant_id' ), $this->get_klarna_variant() );
 		return "https://api{$region}{$playground}.{$domain}/";
 	}
 


### PR DESCRIPTION
New merchants onboarding through Kustoms portal will have a MID that start with M in production or PM in playground.
From 13/6 2025 these new credentials will require all requests to go through the `kustom.co` domain instead of `klarna.com` following the same structure for playground and regions. In cases where merchants have special MIDs, there is also a filter added to support setting the domain manually if needed.

------

* Tweak - API Usernames that start with either M for production or PM for playground will use the `kustom.co` domain instead of `klarna.com` for all API requests. The domain can be changed using the filter `kco_api_domain` to set this manually if needed.